### PR TITLE
Add minor edits to fix functionality.

### DIFF
--- a/hypergeo_enricher.R
+++ b/hypergeo_enricher.R
@@ -64,9 +64,9 @@ enrich.fxn <- function(gene.list=NULL,
   require(msigdbr)
   require(tidyverse)
   require(plyr)
-  if(genome$packageName == "org.Hs.eg.db"){
+  if(genome== "org.Hs.eg.db"){
     require(org.Hs.eg.db)}
-  if(genome$packageName == "org.Mm.eg.db"){
+  if(genome== "org.Mm.eg.db"){
     require(org.Mm.eg.db)}
   
   #Silence warnings
@@ -78,8 +78,7 @@ enrich.fxn <- function(gene.list=NULL,
 ##### Loop through gene df #####
   if(!is.null(gene.df)){
     #List all possible group levels
-    group.list <- unique(gene.df[,df.group]) %>% 
-      dplyr::select(all_of(df.group)) %>% unlist(use.names = FALSE)
+    group.list <- unique(gene.df[,df.group])
     
     for(group.level in group.list){
       print(group.level)
@@ -169,7 +168,7 @@ run.enrich <- function(to.enrich, group.level,
   
 
   #Get database of interest
-  if(genome$packageName == "org.Hs.eg.db"){
+  if(genome == "org.Hs.eg.db"){
     
     #No subcategory
     if(is.null(subcategory)){


### PR DESCRIPTION
1) Update how "genome" specification is handled. This seemed to expect a list with "genome$packageName" specifying the reference to use, wherease the notation indicates that this should be provided directly as character string (ie. "org.Hs.eg.db". Misspecification was throwing errors.

2) Update specification of groups/modules vector over which to loop. This called for generating a vector of groups via "unique(gene.df[,df.group])" which was then piped to dplyr::select(), causing errors.