### PR TITLE
Add contrast specification to lmekin fxn.

### DIFF
--- a/lmekin.fxn.R
+++ b/lmekin.fxn.R
@@ -394,7 +394,7 @@ fit.results <- rbindlist(fill=TRUE, foreach(i=1:nrow(dat.subset$E)) %dopar% {
     bind_rows(results.pair)
   
   #This gene to all previous gene results
-  fit.results <- rbind(results, fit.results) 
+  fit.results <- bind_rows(results, fit.results) 
   })
 
 #### Calculate FDR ####


### PR DESCRIPTION
Adds specification of contrast matrix in place of specifying that all pairwise comparisons should be drawn. Useful when only pre-specified comparisons are of interest, as the multiple testing correction is more lenient. Adds the group comparisons (here outputted as the FC estimate) to results.